### PR TITLE
added support for other units and added an options page to control what units to convert to

### DIFF
--- a/americanify.js
+++ b/americanify.js
@@ -1,10 +1,15 @@
 // Conversion Functions
-function MetersToFeet(meters){
+function convertAltitude(meters){
   var feet = meters * 3.28;
   return feet.toFixed(0);
 }
 
-function KmhToMph(kmh){
+function convertClimbSpeed(metersPerSecond){
+  var feet = metersPerSecond * 60 * 3.28;
+  return feet.toFixed(0);
+}
+
+function convertSpeed(kmh){
   var mph = kmh / 1.609344;
   return mph.toFixed(0);
 }
@@ -76,17 +81,17 @@ async function main() {
       var plane_speed_value = plane_speed.getElementsByClassName("value")[1];
 
       // Convert Max speed at altitude
-      var max_speed_at_feet = MetersToFeet(ParseValue(plane_speed_alti.innerHTML));
+      var max_speed_at_feet = convertAltitude(ParseValue(plane_speed_alti.innerHTML));
       plane_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
 
-      var max_speed_in_mph = KmhToMph(ParseValue(plane_speed_value.innerHTML));
+      var max_speed_in_mph = convertSpeed(ParseValue(plane_speed_value.innerHTML));
       plane_speed_value.innerHTML = max_speed_in_mph + " mph";
       // End max speed conversion
 
       // Convert Max altitude
       var plane_altitude = plane_specs_blocks[2];
       var plane_max_alti = plane_altitude.getElementsByClassName("value")[0];
-      var max_altitude_in_feet = MetersToFeet(ParseValue(plane_max_alti.innerHTML));
+      var max_altitude_in_feet = convertAltitude(ParseValue(plane_max_alti.innerHTML));
       plane_max_alti.innerHTML = max_altitude_in_feet + " feet";
       // End max altitude conversion
     }
@@ -99,7 +104,7 @@ async function main() {
 
       for (var i = 0; i < survivability_specs_block_values.length; i++) {
         if (ParseSpaces(survivability_specs_block_values[i].innerHTML) != "") {
-          var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
+          var destruction_speed = convertSpeed(ParseValue(survivability_specs_block_values[i].innerHTML));
           survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
         }
       }
@@ -142,7 +147,7 @@ async function main() {
 
       // Header Row Conversions
       var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
-      var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
+      var ctrow1_max_speed_at_altitude = convertAltitude(ParseValue(ctrow1_headers[1].innerHTML));
       ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
 
       ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
@@ -153,38 +158,38 @@ async function main() {
       // Stock Row Conversions
       var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
 
-      var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
+      var ctrow3_ms_ab = convertSpeed(ParseValue(ctrow3_stock[0].innerHTML));
       ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
 
-      var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
+      var ctrow3_ms_rb = convertSpeed(ParseValue(ctrow3_stock[1].innerHTML));
       ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
 
-      var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
+      var ctrow3_max_alti = convertAltitude(ParseValue(ctrow3_stock[2].innerHTML));
       ctrow3_stock[2].innerHTML = ctrow3_max_alti;
 
-      var ctrow3_roc_ab = MetersToFeet(ParseValue(ctrow3_stock[5].innerHTML)) * 60;
+      var ctrow3_roc_ab = convertClimbSpeed(ParseValue(ctrow3_stock[5].innerHTML));
       ctrow3_stock[5].innerHTML = ctrow3_roc_ab;
 
-      var ctrow3_roc_rb = MetersToFeet(ParseValue(ctrow3_stock[6].innerHTML)) * 60;
+      var ctrow3_roc_rb = convertClimbSpeed(ParseValue(ctrow3_stock[6].innerHTML));
       ctrow3_stock[6].innerHTML = ctrow3_roc_rb;
 
-      var ctrow3_tor = MetersToFeet(ParseValue(ctrow3_stock[7].innerHTML));
+      var ctrow3_tor = convertAltitude(ParseValue(ctrow3_stock[7].innerHTML));
       ctrow3_stock[7].innerHTML = ctrow3_tor;
       // End Stock Row Conversions
 
       // Upgraded Row Conversions
       var ctrow4_stock = ctable_rows[3].getElementsByTagName("td");
 
-      var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_stock[0].innerHTML));
+      var ctrow4_ms_ab = convertSpeed(ParseValue(ctrow4_stock[0].innerHTML));
       ctrow4_stock[0].innerHTML = ctrow4_ms_ab;
 
-      var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_stock[1].innerHTML));
+      var ctrow4_ms_rb = convertSpeed(ParseValue(ctrow4_stock[1].innerHTML));
       ctrow4_stock[1].innerHTML = ctrow4_ms_rb;
 
-      var ctrow4_roc_ab = MetersToFeet(ParseValue(ctrow4_stock[4].innerHTML)) * 60;
+      var ctrow4_roc_ab = convertClimbSpeed(ParseValue(ctrow4_stock[4].innerHTML));
       ctrow4_stock[4].innerHTML = ctrow4_roc_ab;
 
-      var ctrow4_roc_rb = MetersToFeet(ParseValue(ctrow4_stock[5].innerHTML)) * 60;
+      var ctrow4_roc_rb = convertClimbSpeed(ParseValue(ctrow4_stock[5].innerHTML));
       ctrow4_stock[5].innerHTML = ctrow4_roc_rb;
       // End Upgraded Row Conversions
     }
@@ -205,22 +210,22 @@ async function main() {
       // Limits Row Conversions
       var ltrow3_limits = ltable_rows[3].getElementsByTagName("td");
 
-      var ltrow3_wings_limit = KmhToMph(ParseValue(ltrow3_limits[0].innerHTML));
+      var ltrow3_wings_limit = convertSpeed(ParseValue(ltrow3_limits[0].innerHTML));
       ltrow3_limits[0].innerHTML = ltrow3_wings_limit;
 
-      var ltrow3_gear_limit = KmhToMph(ParseValue(ltrow3_limits[1].innerHTML));
+      var ltrow3_gear_limit = convertSpeed(ParseValue(ltrow3_limits[1].innerHTML));
       ltrow3_limits[1].innerHTML = ltrow3_gear_limit;
 
       if (ParseSpaces(ltrow3_limits[2].innerHTML) != "N/A") {
-        var ltrow3_cmbt_flaps = KmhToMph(ParseValue(ltrow3_limits[2].innerHTML));
+        var ltrow3_cmbt_flaps = convertSpeed(ParseValue(ltrow3_limits[2].innerHTML));
         ltrow3_limits[2].innerHTML = ltrow3_cmbt_flaps;
       }
       if (ParseSpaces(ltrow3_limits[3].innerHTML) != "N/A") {
-        var ltrow3_to_flaps = KmhToMph(ParseValue(ltrow3_limits[3].innerHTML));
+        var ltrow3_to_flaps = convertSpeed(ParseValue(ltrow3_limits[3].innerHTML));
         ltrow3_limits[3].innerHTML = ltrow3_to_flaps;
       }
       if (ParseSpaces(ltrow3_limits[4].innerHTML) != "N/A") {
-        var ltrow3_landing_flaps = KmhToMph(ParseValue(ltrow3_limits[4].innerHTML));
+        var ltrow3_landing_flaps = convertSpeed(ParseValue(ltrow3_limits[4].innerHTML));
         ltrow3_limits[4].innerHTML = ltrow3_landing_flaps;
       }
       // End Limits Row Conversions
@@ -244,7 +249,7 @@ async function main() {
           sign = sign.substr(0, 4);
 
           if (ParseValue(vtrow_optimals[i].innerHTML) != "") { // Fix for when wiki does not list optimal velocities: ex "< ___" or "> ___"
-            var optimal_conversion = KmhToMph(ParseValue(vtrow_optimals[i].innerHTML));
+            var optimal_conversion = convertSpeed(ParseValue(vtrow_optimals[i].innerHTML));
             vtrow_optimals[i].innerHTML = sign + " " + optimal_conversion;
           }
         }
@@ -257,7 +262,7 @@ async function main() {
       var comptable_rows = compressor_table.getElementsByTagName("tr");
       var comptable_optimalaltitude = comptable_rows[3].getElementsByTagName("td")[0];
 
-      var converted_altitude = MetersToFeet(ParseValue(comptable_optimalaltitude.innerHTML));
+      var converted_altitude = convertAltitude(ParseValue(comptable_optimalaltitude.innerHTML));
       comptable_optimalaltitude.innerHTML = converted_altitude + " feet";
     }
   }
@@ -284,8 +289,8 @@ async function main() {
       for (var i = 0; i < fleet_mobility_values.length; i++) {
         if (ParseSpaces(fleet_mobility_values[i].innerHTML) != "forward/back") {
           var speed_values = ParseSpaces(fleet_mobility_values[i].innerHTML).split("/");
-          var forward = KmhToMph(ParseValue(speed_values[0]));
-          var backward = KmhToMph(ParseValue(speed_values[1]));
+          var forward = convertSpeed(ParseValue(speed_values[0]));
+          var backward = convertSpeed(ParseValue(speed_values[1]));
 
           fleet_mobility_values[i].innerHTML = forward + " / " + backward + " mph";
         }
@@ -319,20 +324,20 @@ async function main() {
       // AB Row Conversions
       var mctrow3_ab = mctable_rows[4].getElementsByTagName("td");
 
-      var mctrow3_forward = KmhToMph(ParseValue(mctrow3_ab[1].innerHTML));
+      var mctrow3_forward = convertSpeed(ParseValue(mctrow3_ab[1].innerHTML));
       mctrow3_ab[1].innerHTML = mctrow3_forward;
 
-      var mctrow3_reverse = KmhToMph(ParseValue(mctrow3_ab[2].innerHTML));
+      var mctrow3_reverse = convertSpeed(ParseValue(mctrow3_ab[2].innerHTML));
       mctrow3_ab[2].innerHTML = mctrow3_reverse;
       // End AB Row Conversions
 
       // RB/SB Row Conversions
       var mctrow4_rbsb = mctable_rows[6].getElementsByTagName("td");
 
-      var mctrow4_forward = KmhToMph(ParseValue(mctrow4_rbsb[1].innerHTML));
+      var mctrow4_forward = convertSpeed(ParseValue(mctrow4_rbsb[1].innerHTML));
       mctrow4_rbsb[1].innerHTML = mctrow4_forward;
 
-      var mctrow4_reverse = KmhToMph(ParseValue(mctrow4_rbsb[2].innerHTML));
+      var mctrow4_reverse = convertSpeed(ParseValue(mctrow4_rbsb[2].innerHTML));
       mctrow4_rbsb[2].innerHTML = mctrow4_reverse;
       // End RB/SB Row Conversions
     }
@@ -362,8 +367,8 @@ async function main() {
       for (var i = 0; i < ground_speed_values.length; i++) {
         if (ParseSpaces(ground_speed_values[i].innerHTML) != "forward/back") {
           var speed_values = ParseSpaces(ground_speed_values[i].innerHTML).split("/");
-          var forward = KmhToMph(ParseValue(speed_values[0]));
-          var backward = KmhToMph(ParseValue(speed_values[1]));
+          var forward = convertSpeed(ParseValue(speed_values[0]));
+          var backward = convertSpeed(ParseValue(speed_values[1]));
 
           ground_speed_values[i].innerHTML = forward + " / " + backward + " mph";
         }
@@ -396,20 +401,20 @@ async function main() {
       // Arcade Row Conversions
       var gctrow3_arcade = gctable_rows[2].getElementsByTagName("td");
 
-      var gctrow3_forward = KmhToMph(ParseValue(gctrow3_arcade[0].innerHTML));
+      var gctrow3_forward = convertSpeed(ParseValue(gctrow3_arcade[0].innerHTML));
       gctrow3_arcade[0].innerHTML = gctrow3_forward;
 
-      var gctrow3_reverse = KmhToMph(ParseValue(gctrow3_arcade[1].innerHTML));
+      var gctrow3_reverse = convertSpeed(ParseValue(gctrow3_arcade[1].innerHTML));
       gctrow3_arcade[1].innerHTML = gctrow3_reverse;
       // End AB Row Conversions
 
       // Realistic Row Conversions
       var gctrow4_realistics = gctable_rows[3].getElementsByTagName("td");
 
-      var gctrow4_forward = KmhToMph(ParseValue(gctrow4_realistics[0].innerHTML));
+      var gctrow4_forward = convertSpeed(ParseValue(gctrow4_realistics[0].innerHTML));
       gctrow4_realistics[0].innerHTML = gctrow4_forward;
 
-      var gctrow4_reverse = KmhToMph(ParseValue(gctrow4_realistics[1].innerHTML));
+      var gctrow4_reverse = convertSpeed(ParseValue(gctrow4_realistics[1].innerHTML));
       gctrow4_realistics[1].innerHTML = gctrow4_reverse;
       // End RB/SB Row Conversions
     }
@@ -447,17 +452,17 @@ async function main() {
       var heli_speed_value = heli_speed.getElementsByClassName("value")[1];
 
       // Convert Max speed at altitude
-      var max_speed_at_feet = MetersToFeet(ParseValue(heli_speed_alti.innerHTML));
+      var max_speed_at_feet = convertAltitude(ParseValue(heli_speed_alti.innerHTML));
       heli_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
 
-      var max_speed_in_mph = KmhToMph(ParseValue(heli_speed_value.innerHTML));
+      var max_speed_in_mph = convertSpeed(ParseValue(heli_speed_value.innerHTML));
       heli_speed_value.innerHTML = max_speed_in_mph + " mph";
       // End max speed conversion
 
       // Convert Max altitude
       var heli_altitude = heli_specs_blocks[1];
       var heli_max_alti = heli_altitude.getElementsByClassName("value")[0];
-      var max_altitude_in_feet = MetersToFeet(ParseValue(heli_max_alti.innerHTML));
+      var max_altitude_in_feet = convertAltitude(ParseValue(heli_max_alti.innerHTML));
       heli_max_alti.innerHTML = max_altitude_in_feet + " feet";
       // End max altitude conversion
     }
@@ -470,7 +475,7 @@ async function main() {
 
       for (var i = 0; i < survivability_specs_block_values.length; i++) {
         if (ParseSpaces(survivability_specs_block_values[i].innerHTML) != "") {
-          var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
+          var destruction_speed = convertSpeed(ParseValue(survivability_specs_block_values[i].innerHTML));
           survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
         }
       }
@@ -495,7 +500,7 @@ async function main() {
 
       // Header Row Conversions
       var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
-      var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
+      var ctrow1_max_speed_at_altitude = convertAltitude(ParseValue(ctrow1_headers[1].innerHTML));
       ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
 
       ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
@@ -504,23 +509,23 @@ async function main() {
       // Stock Row Conversions
       var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
 
-      var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
+      var ctrow3_ms_ab = convertSpeed(ParseValue(ctrow3_stock[0].innerHTML));
       ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
 
-      var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
+      var ctrow3_ms_rb = convertSpeed(ParseValue(ctrow3_stock[1].innerHTML));
       ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
 
-      var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
+      var ctrow3_max_alti = convertAltitude(ParseValue(ctrow3_stock[2].innerHTML));
       ctrow3_stock[2].innerHTML = ctrow3_max_alti;
       // End Stock Row Conversions
 
       // Upgraded Row Conversions
       var ctrow4_upgraded = ctable_rows[3].getElementsByTagName("td");
 
-      var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_upgraded[0].innerHTML));
+      var ctrow4_ms_ab = convertSpeed(ParseValue(ctrow4_upgraded[0].innerHTML));
       ctrow4_upgraded[0].innerHTML = ctrow4_ms_ab;
 
-      var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_upgraded[1].innerHTML));
+      var ctrow4_ms_rb = convertSpeed(ParseValue(ctrow4_upgraded[1].innerHTML));
       ctrow4_upgraded[1].innerHTML = ctrow4_ms_rb;
       // End Upgraded Row Conversions
     }

--- a/americanify.js
+++ b/americanify.js
@@ -23,504 +23,508 @@ function ParseValue(input){
   return output; // return "1500"
 }
 
-// Main Code
-var page_type;
-// Determine Page Type;
-var links = document.getElementsByTagName("a");
-for(var i = 0; i < links.length; i++){
-  if(links[i].title == "Category:Aviation"){
-    page_type = "aviation";
-    break;
-  }
-  if(links[i].title == "Category:Fleet"){
-    page_type = "fleet";
-    break;
-  }
-  if(links[i].title == "Category:Ground vehicles"){
-    page_type = "ground";
-    break;
-  }
-  if(links[i].title == "Category:Helicopters"){
-    page_type = "helicopters";
-    break;
-  }
-}
-
-// Aircraft Page Conversion
-if(page_type == "aviation"){
-  var page_specs_info = document.getElementsByClassName("specs_info");
-
-  var plane_specs;
-  var survivability_specs;
-
-  for(var i = 0; i < page_specs_info.length;i++){
-    // Find Plane Specs
-    if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Maxspeed"){
-      plane_specs = page_specs_info[i];
+async function main() {
+  // Main Code
+  var page_type;
+  // Determine Page Type;
+  var links = document.getElementsByTagName("a");
+  for (var i = 0; i < links.length; i++) {
+    if (links[i].title == "Category:Aviation") {
+      page_type = "aviation";
+      break;
     }
+    if (links[i].title == "Category:Fleet") {
+      page_type = "fleet";
+      break;
+    }
+    if (links[i].title == "Category:Ground vehicles") {
+      page_type = "ground";
+      break;
+    }
+    if (links[i].title == "Category:Helicopters") {
+      page_type = "helicopters";
+      break;
+    }
+  }
 
-    // Find Survivability Specs
-    if(page_specs_info[i].getElementsByClassName("name")[1]){
-      if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[1].innerHTML) == "Speedofdestruction"){
-        survivability_specs = page_specs_info[i];
+  // Aircraft Page Conversion
+  if (page_type == "aviation") {
+    var page_specs_info = document.getElementsByClassName("specs_info");
+
+    var plane_specs;
+    var survivability_specs;
+
+    for (var i = 0; i < page_specs_info.length; i++) {
+      // Find Plane Specs
+      if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Maxspeed") {
+        plane_specs = page_specs_info[i];
       }
-    }
-  }
 
-  // Flight performance conversion
-  if(plane_specs){
-    var plane_specs_blocks = plane_specs.getElementsByClassName("specs_char_block");
-    var plane_speed = plane_specs_blocks[0];
-    var plane_speed_alti = plane_speed.getElementsByClassName("name")[1];
-    var plane_speed_value = plane_speed.getElementsByClassName("value")[1];
-
-    // Convert Max speed at altitude
-    var max_speed_at_feet = MetersToFeet(ParseValue(plane_speed_alti.innerHTML));
-    plane_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
-
-    var max_speed_in_mph = KmhToMph(ParseValue(plane_speed_value.innerHTML));
-    plane_speed_value.innerHTML = max_speed_in_mph + " mph";
-    // End max speed conversion
-
-    // Convert Max altitude
-    var plane_altitude = plane_specs_blocks[2];
-    var plane_max_alti = plane_altitude.getElementsByClassName("value")[0];
-    var max_altitude_in_feet = MetersToFeet(ParseValue(plane_max_alti.innerHTML));
-    plane_max_alti.innerHTML = max_altitude_in_feet + " feet";
-    // End max altitude conversion
-  }
-  // End flight performance conversions
-
-  // Flight Survivability Conversions
-  if(survivability_specs){
-    var survivability_specs_block = survivability_specs.getElementsByClassName("specs_char_block")[1];
-    var survivability_specs_block_values = survivability_specs_block.getElementsByClassName("value");
-
-    for(var i = 0; i < survivability_specs_block_values.length; i++){
-      if(ParseSpaces(survivability_specs_block_values[i].innerHTML) != ""){
-        var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
-        survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
-      }
-    }
-  }
-  // End Survivability Conversions
-
-  var wiki_tables = document.getElementsByClassName("wikitable");
-
-  // Find Data Tables
-  var characteristics_table;
-  var limits_table;
-  var velocities_table;
-  var compressor_table;
-  for(var i = 0; i < wiki_tables.length; i++){
-    // Check if Characteristics Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Characteristics"){
-      characteristics_table = wiki_tables[i]
-    }
-
-    // Check if Limits Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Limits"){
-      limits_table = wiki_tables[i]
-    }
-
-    // Check if Optimal Velocities Tables
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Optimalvelocities(km/h)"){
-      velocities_table = wiki_tables[i]
-    }
-
-    // Check if Compressor Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Compressor(RB/SB)"){
-      compressor_table = wiki_tables[i]
-    }
-  }
-
-  // Vehicle Characteristics Table Conversion
-  if(characteristics_table){
-    // Get all rows
-    var ctable_rows = characteristics_table.getElementsByTagName("tr");
-
-    // Header Row Conversions
-    var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
-    var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
-    ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
-
-    ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
-    ctrow1_headers[4].innerHTML = "Rate of Climb <br> (feet/minute)";
-    ctrow1_headers[5].innerHTML = "Take-off Run <br> (feet)";
-    // End Header Row Conversions
-
-    // Stock Row Conversions
-    var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
-
-    var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
-    ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
-
-    var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
-    ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
-
-    var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
-    ctrow3_stock[2].innerHTML = ctrow3_max_alti;
-
-    var ctrow3_roc_ab = MetersToFeet(ParseValue(ctrow3_stock[5].innerHTML)) * 60;
-    ctrow3_stock[5].innerHTML = ctrow3_roc_ab;
-
-    var ctrow3_roc_rb = MetersToFeet(ParseValue(ctrow3_stock[6].innerHTML)) * 60;
-    ctrow3_stock[6].innerHTML = ctrow3_roc_rb;
-
-    var ctrow3_tor = MetersToFeet(ParseValue(ctrow3_stock[7].innerHTML));
-    ctrow3_stock[7].innerHTML = ctrow3_tor;
-    // End Stock Row Conversions
-
-    // Upgraded Row Conversions
-    var ctrow4_stock = ctable_rows[3].getElementsByTagName("td");
-
-    var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_stock[0].innerHTML));
-    ctrow4_stock[0].innerHTML = ctrow4_ms_ab;
-
-    var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_stock[1].innerHTML));
-    ctrow4_stock[1].innerHTML = ctrow4_ms_rb;
-
-    var ctrow4_roc_ab = MetersToFeet(ParseValue(ctrow4_stock[4].innerHTML)) * 60;
-    ctrow4_stock[4].innerHTML = ctrow4_roc_ab;
-
-    var ctrow4_roc_rb = MetersToFeet(ParseValue(ctrow4_stock[5].innerHTML)) * 60;
-    ctrow4_stock[5].innerHTML = ctrow4_roc_rb;
-    // End Upgraded Row Conversions
-  }
-
-  // Vehicle Limits Table Conversion
-  if(limits_table){
-    // Get all rows
-    var ltable_rows = limits_table.getElementsByTagName("tr");
-
-    // Header Row Conversions
-    var ltrow1_headers = ltable_rows[1].getElementsByTagName("th");
-
-    ltrow1_headers[0].innerHTML = "Wings (mph)";
-    ltrow1_headers[1].innerHTML = "Gear (mph)";
-    ltrow1_headers[2].innerHTML = "Flaps (mph)";
-    // End Header Row Conversions
-
-    // Limits Row Conversions
-    var ltrow3_limits = ltable_rows[3].getElementsByTagName("td");
-
-    var ltrow3_wings_limit = KmhToMph(ParseValue(ltrow3_limits[0].innerHTML));
-    ltrow3_limits[0].innerHTML = ltrow3_wings_limit;
-
-    var ltrow3_gear_limit = KmhToMph(ParseValue(ltrow3_limits[1].innerHTML));
-    ltrow3_limits[1].innerHTML = ltrow3_gear_limit;
-
-    if(ParseSpaces(ltrow3_limits[2].innerHTML) != "N/A"){
-      var ltrow3_cmbt_flaps = KmhToMph(ParseValue(ltrow3_limits[2].innerHTML));
-      ltrow3_limits[2].innerHTML = ltrow3_cmbt_flaps;
-    }
-    if(ParseSpaces(ltrow3_limits[3].innerHTML) != "N/A"){
-      var ltrow3_to_flaps = KmhToMph(ParseValue(ltrow3_limits[3].innerHTML));
-      ltrow3_limits[3].innerHTML = ltrow3_to_flaps;
-    }
-    if(ParseSpaces(ltrow3_limits[4].innerHTML) != "N/A"){
-      var ltrow3_landing_flaps = KmhToMph(ParseValue(ltrow3_limits[4].innerHTML));
-      ltrow3_limits[4].innerHTML = ltrow3_landing_flaps;
-    }
-    // End Limits Row Conversions
-  }
-
-  // Optimal Velocity Table Conversion
-  if(velocities_table){
-    var vtable_rows = velocities_table.getElementsByTagName("tr");
-
-    // Header Row Conversions
-    var vtrow_headers = vtable_rows[0].getElementsByTagName("th");
-    vtrow_headers[0].innerHTML = "Optimal velocities (mph)";
-    // End Header Row Conversions
-
-    // Optimal Velocities Row Conversions
-    var vtrow_optimals = vtable_rows[2].getElementsByTagName("td");
-
-    for(var i = 0; i < vtrow_optimals.length; i++){
-      if(ParseSpaces(vtrow_optimals[i].innerHTML) != "N/A"){
-        var sign = ParseSpaces(vtrow_optimals[i].innerHTML);
-        sign = sign.substr(0,4);
-
-        if(ParseValue(vtrow_optimals[i].innerHTML) != ""){ // Fix for when wiki does not list optimal velocities: ex "< ___" or "> ___"
-          var optimal_conversion = KmhToMph(ParseValue(vtrow_optimals[i].innerHTML));
-          vtrow_optimals[i].innerHTML = sign + " " + optimal_conversion;
+      // Find Survivability Specs
+      if (page_specs_info[i].getElementsByClassName("name")[1]) {
+        if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[1].innerHTML) == "Speedofdestruction") {
+          survivability_specs = page_specs_info[i];
         }
       }
     }
-    // End Optimal Velocities Row Conversions
-  }
 
-  // Compressor Table Optimal Altitude Conversion
-  if(compressor_table){
-    var comptable_rows = compressor_table.getElementsByTagName("tr");
-    var comptable_optimalaltitude = comptable_rows[3].getElementsByTagName("td")[0];
+    // Flight performance conversion
+    if (plane_specs) {
+      var plane_specs_blocks = plane_specs.getElementsByClassName("specs_char_block");
+      var plane_speed = plane_specs_blocks[0];
+      var plane_speed_alti = plane_speed.getElementsByClassName("name")[1];
+      var plane_speed_value = plane_speed.getElementsByClassName("value")[1];
 
-    var converted_altitude = MetersToFeet(ParseValue(comptable_optimalaltitude.innerHTML));
-    comptable_optimalaltitude.innerHTML = converted_altitude + " feet";
-  }
-}
-// End Aircraft Page Conversions
+      // Convert Max speed at altitude
+      var max_speed_at_feet = MetersToFeet(ParseValue(plane_speed_alti.innerHTML));
+      plane_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
 
-// Fleet Page Conversion
-if(page_type == "fleet"){
-  var page_specs_info = document.getElementsByClassName("specs_info");
+      var max_speed_in_mph = KmhToMph(ParseValue(plane_speed_value.innerHTML));
+      plane_speed_value.innerHTML = max_speed_in_mph + " mph";
+      // End max speed conversion
 
-  var mobility_specs;
-
-  for(var i = 0; i < page_specs_info.length;i++){
-    // Find Mobility Specs
-    if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Speed"){
-      mobility_specs = page_specs_info[i];
+      // Convert Max altitude
+      var plane_altitude = plane_specs_blocks[2];
+      var plane_max_alti = plane_altitude.getElementsByClassName("value")[0];
+      var max_altitude_in_feet = MetersToFeet(ParseValue(plane_max_alti.innerHTML));
+      plane_max_alti.innerHTML = max_altitude_in_feet + " feet";
+      // End max altitude conversion
     }
-  }
+    // End flight performance conversions
 
-  // Convert Mobility Specs
-  if(mobility_specs){
-    var fleet_mobility_block = mobility_specs.getElementsByClassName("specs_char_block")[0];
-    var fleet_mobility_values = fleet_mobility_block.getElementsByClassName("value");
+    // Flight Survivability Conversions
+    if (survivability_specs) {
+      var survivability_specs_block = survivability_specs.getElementsByClassName("specs_char_block")[1];
+      var survivability_specs_block_values = survivability_specs_block.getElementsByClassName("value");
 
-    for(var i = 0; i < fleet_mobility_values.length; i++){
-      if(ParseSpaces(fleet_mobility_values[i].innerHTML) != "forward/back"){
-        var speed_values = ParseSpaces(fleet_mobility_values[i].innerHTML).split("/");
-        var forward = KmhToMph(ParseValue(speed_values[0]));
-        var backward = KmhToMph(ParseValue(speed_values[1]));
-
-        fleet_mobility_values[i].innerHTML = forward + " / " + backward + " mph";
+      for (var i = 0; i < survivability_specs_block_values.length; i++) {
+        if (ParseSpaces(survivability_specs_block_values[i].innerHTML) != "") {
+          var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
+          survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
+        }
       }
     }
-  }
-  // End Mobility Specs
+    // End Survivability Conversions
 
-  //
-  var wiki_tables = document.getElementsByClassName("wikitable");
+    var wiki_tables = document.getElementsByClassName("wikitable");
 
-  // Find Data Tables
-  var mobility_characteristics_table;
-  for(var i = 0; i < wiki_tables.length; i++){
-    // Check if Mobility Characteristics Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[1].getElementsByTagName("th")[0].innerHTML) == "GameMode"){
-      console.log("found");
-      mobility_characteristics_table = wiki_tables[i]
+    // Find Data Tables
+    var characteristics_table;
+    var limits_table;
+    var velocities_table;
+    var compressor_table;
+    for (var i = 0; i < wiki_tables.length; i++) {
+      // Check if Characteristics Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Characteristics") {
+        characteristics_table = wiki_tables[i]
+      }
+
+      // Check if Limits Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Limits") {
+        limits_table = wiki_tables[i]
+      }
+
+      // Check if Optimal Velocities Tables
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Optimalvelocities(km/h)") {
+        velocities_table = wiki_tables[i]
+      }
+
+      // Check if Compressor Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Compressor(RB/SB)") {
+        compressor_table = wiki_tables[i]
+      }
+    }
+
+    // Vehicle Characteristics Table Conversion
+    if (characteristics_table) {
+      // Get all rows
+      var ctable_rows = characteristics_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
+      var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
+      ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
+
+      ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
+      ctrow1_headers[4].innerHTML = "Rate of Climb <br> (feet/minute)";
+      ctrow1_headers[5].innerHTML = "Take-off Run <br> (feet)";
+      // End Header Row Conversions
+
+      // Stock Row Conversions
+      var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
+
+      var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
+      ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
+
+      var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
+      ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
+
+      var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
+      ctrow3_stock[2].innerHTML = ctrow3_max_alti;
+
+      var ctrow3_roc_ab = MetersToFeet(ParseValue(ctrow3_stock[5].innerHTML)) * 60;
+      ctrow3_stock[5].innerHTML = ctrow3_roc_ab;
+
+      var ctrow3_roc_rb = MetersToFeet(ParseValue(ctrow3_stock[6].innerHTML)) * 60;
+      ctrow3_stock[6].innerHTML = ctrow3_roc_rb;
+
+      var ctrow3_tor = MetersToFeet(ParseValue(ctrow3_stock[7].innerHTML));
+      ctrow3_stock[7].innerHTML = ctrow3_tor;
+      // End Stock Row Conversions
+
+      // Upgraded Row Conversions
+      var ctrow4_stock = ctable_rows[3].getElementsByTagName("td");
+
+      var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_stock[0].innerHTML));
+      ctrow4_stock[0].innerHTML = ctrow4_ms_ab;
+
+      var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_stock[1].innerHTML));
+      ctrow4_stock[1].innerHTML = ctrow4_ms_rb;
+
+      var ctrow4_roc_ab = MetersToFeet(ParseValue(ctrow4_stock[4].innerHTML)) * 60;
+      ctrow4_stock[4].innerHTML = ctrow4_roc_ab;
+
+      var ctrow4_roc_rb = MetersToFeet(ParseValue(ctrow4_stock[5].innerHTML)) * 60;
+      ctrow4_stock[5].innerHTML = ctrow4_roc_rb;
+      // End Upgraded Row Conversions
+    }
+
+    // Vehicle Limits Table Conversion
+    if (limits_table) {
+      // Get all rows
+      var ltable_rows = limits_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var ltrow1_headers = ltable_rows[1].getElementsByTagName("th");
+
+      ltrow1_headers[0].innerHTML = "Wings (mph)";
+      ltrow1_headers[1].innerHTML = "Gear (mph)";
+      ltrow1_headers[2].innerHTML = "Flaps (mph)";
+      // End Header Row Conversions
+
+      // Limits Row Conversions
+      var ltrow3_limits = ltable_rows[3].getElementsByTagName("td");
+
+      var ltrow3_wings_limit = KmhToMph(ParseValue(ltrow3_limits[0].innerHTML));
+      ltrow3_limits[0].innerHTML = ltrow3_wings_limit;
+
+      var ltrow3_gear_limit = KmhToMph(ParseValue(ltrow3_limits[1].innerHTML));
+      ltrow3_limits[1].innerHTML = ltrow3_gear_limit;
+
+      if (ParseSpaces(ltrow3_limits[2].innerHTML) != "N/A") {
+        var ltrow3_cmbt_flaps = KmhToMph(ParseValue(ltrow3_limits[2].innerHTML));
+        ltrow3_limits[2].innerHTML = ltrow3_cmbt_flaps;
+      }
+      if (ParseSpaces(ltrow3_limits[3].innerHTML) != "N/A") {
+        var ltrow3_to_flaps = KmhToMph(ParseValue(ltrow3_limits[3].innerHTML));
+        ltrow3_limits[3].innerHTML = ltrow3_to_flaps;
+      }
+      if (ParseSpaces(ltrow3_limits[4].innerHTML) != "N/A") {
+        var ltrow3_landing_flaps = KmhToMph(ParseValue(ltrow3_limits[4].innerHTML));
+        ltrow3_limits[4].innerHTML = ltrow3_landing_flaps;
+      }
+      // End Limits Row Conversions
+    }
+
+    // Optimal Velocity Table Conversion
+    if (velocities_table) {
+      var vtable_rows = velocities_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var vtrow_headers = vtable_rows[0].getElementsByTagName("th");
+      vtrow_headers[0].innerHTML = "Optimal velocities (mph)";
+      // End Header Row Conversions
+
+      // Optimal Velocities Row Conversions
+      var vtrow_optimals = vtable_rows[2].getElementsByTagName("td");
+
+      for (var i = 0; i < vtrow_optimals.length; i++) {
+        if (ParseSpaces(vtrow_optimals[i].innerHTML) != "N/A") {
+          var sign = ParseSpaces(vtrow_optimals[i].innerHTML);
+          sign = sign.substr(0, 4);
+
+          if (ParseValue(vtrow_optimals[i].innerHTML) != "") { // Fix for when wiki does not list optimal velocities: ex "< ___" or "> ___"
+            var optimal_conversion = KmhToMph(ParseValue(vtrow_optimals[i].innerHTML));
+            vtrow_optimals[i].innerHTML = sign + " " + optimal_conversion;
+          }
+        }
+      }
+      // End Optimal Velocities Row Conversions
+    }
+
+    // Compressor Table Optimal Altitude Conversion
+    if (compressor_table) {
+      var comptable_rows = compressor_table.getElementsByTagName("tr");
+      var comptable_optimalaltitude = comptable_rows[3].getElementsByTagName("td")[0];
+
+      var converted_altitude = MetersToFeet(ParseValue(comptable_optimalaltitude.innerHTML));
+      comptable_optimalaltitude.innerHTML = converted_altitude + " feet";
     }
   }
+  // End Aircraft Page Conversions
 
-  // Vehicle Characteristics Table Conversion
-  if(mobility_characteristics_table){
-    // Get all rows
-    var mctable_rows = mobility_characteristics_table.getElementsByTagName("tr");
+  // Fleet Page Conversion
+  if (page_type == "fleet") {
+    var page_specs_info = document.getElementsByClassName("specs_info");
 
-    // Header Row Conversions
-    var mctrow1_headers = mctable_rows[1].getElementsByTagName("th");
-    mctrow1_headers[2].innerHTML = "Maximum Speed (mph)";
-    // End Header Row Conversions
+    var mobility_specs;
 
-    // AB Row Conversions
-    var mctrow3_ab = mctable_rows[4].getElementsByTagName("td");
-
-    var mctrow3_forward = KmhToMph(ParseValue(mctrow3_ab[1].innerHTML));
-    mctrow3_ab[1].innerHTML = mctrow3_forward;
-
-    var mctrow3_reverse = KmhToMph(ParseValue(mctrow3_ab[2].innerHTML));
-    mctrow3_ab[2].innerHTML = mctrow3_reverse;
-    // End AB Row Conversions
-
-    // RB/SB Row Conversions
-    var mctrow4_rbsb = mctable_rows[6].getElementsByTagName("td");
-
-    var mctrow4_forward = KmhToMph(ParseValue(mctrow4_rbsb[1].innerHTML));
-    mctrow4_rbsb[1].innerHTML = mctrow4_forward;
-
-    var mctrow4_reverse = KmhToMph(ParseValue(mctrow4_rbsb[2].innerHTML));
-    mctrow4_rbsb[2].innerHTML = mctrow4_reverse;
-    // End RB/SB Row Conversions
-  }
-}
-// End Fleet Page Conversions
-
-// Ground Page Conversions
-if(page_type == "ground"){
-  var page_specs_info = document.getElementsByClassName("specs_info");
-
-  var mobility_specs;
-
-  for(var i = 0; i < page_specs_info.length; i++){
-    // Find Mobility Specs
-    if(page_specs_info[i].getElementsByClassName("name")[0]){
-      if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Speed"){
+    for (var i = 0; i < page_specs_info.length; i++) {
+      // Find Mobility Specs
+      if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Speed") {
         mobility_specs = page_specs_info[i];
       }
     }
-  }
 
-  // Convert Mobility Specs
-  if(mobility_specs){
-    var ground_mobility_block = mobility_specs.getElementsByClassName("specs_char_block")[0];
-    var ground_speed_values = ground_mobility_block.getElementsByClassName("value");
+    // Convert Mobility Specs
+    if (mobility_specs) {
+      var fleet_mobility_block = mobility_specs.getElementsByClassName("specs_char_block")[0];
+      var fleet_mobility_values = fleet_mobility_block.getElementsByClassName("value");
 
-    for(var i = 0; i < ground_speed_values.length; i++){
-      if(ParseSpaces(ground_speed_values[i].innerHTML) != "forward/back"){
-        var speed_values = ParseSpaces(ground_speed_values[i].innerHTML).split("/");
-        var forward = KmhToMph(ParseValue(speed_values[0]));
-        var backward = KmhToMph(ParseValue(speed_values[1]));
+      for (var i = 0; i < fleet_mobility_values.length; i++) {
+        if (ParseSpaces(fleet_mobility_values[i].innerHTML) != "forward/back") {
+          var speed_values = ParseSpaces(fleet_mobility_values[i].innerHTML).split("/");
+          var forward = KmhToMph(ParseValue(speed_values[0]));
+          var backward = KmhToMph(ParseValue(speed_values[1]));
 
-        ground_speed_values[i].innerHTML = forward + " / " + backward + " mph";
+          fleet_mobility_values[i].innerHTML = forward + " / " + backward + " mph";
+        }
       }
     }
-  }
-  // End Mobility Specs
+    // End Mobility Specs
 
-  var wiki_tables = document.getElementsByClassName("wikitable");
+    //
+    var wiki_tables = document.getElementsByClassName("wikitable");
 
-  // Find Data Tables
-  var ground_characteristics_table;
-  for(var i = 0; i < wiki_tables.length; i++){
-    // Check if Mobility Characteristics Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "GameMode"){
-      console.log("found");
-      ground_characteristics_table = wiki_tables[i]
+    // Find Data Tables
+    var mobility_characteristics_table;
+    for (var i = 0; i < wiki_tables.length; i++) {
+      // Check if Mobility Characteristics Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[1].getElementsByTagName("th")[0].innerHTML) == "GameMode") {
+        console.log("found");
+        mobility_characteristics_table = wiki_tables[i]
+      }
+    }
+
+    // Vehicle Characteristics Table Conversion
+    if (mobility_characteristics_table) {
+      // Get all rows
+      var mctable_rows = mobility_characteristics_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var mctrow1_headers = mctable_rows[1].getElementsByTagName("th");
+      mctrow1_headers[2].innerHTML = "Maximum Speed (mph)";
+      // End Header Row Conversions
+
+      // AB Row Conversions
+      var mctrow3_ab = mctable_rows[4].getElementsByTagName("td");
+
+      var mctrow3_forward = KmhToMph(ParseValue(mctrow3_ab[1].innerHTML));
+      mctrow3_ab[1].innerHTML = mctrow3_forward;
+
+      var mctrow3_reverse = KmhToMph(ParseValue(mctrow3_ab[2].innerHTML));
+      mctrow3_ab[2].innerHTML = mctrow3_reverse;
+      // End AB Row Conversions
+
+      // RB/SB Row Conversions
+      var mctrow4_rbsb = mctable_rows[6].getElementsByTagName("td");
+
+      var mctrow4_forward = KmhToMph(ParseValue(mctrow4_rbsb[1].innerHTML));
+      mctrow4_rbsb[1].innerHTML = mctrow4_forward;
+
+      var mctrow4_reverse = KmhToMph(ParseValue(mctrow4_rbsb[2].innerHTML));
+      mctrow4_rbsb[2].innerHTML = mctrow4_reverse;
+      // End RB/SB Row Conversions
     }
   }
+  // End Fleet Page Conversions
 
-  // Vehicle Characteristics Table Conversion
-  if(ground_characteristics_table){
-    // Get all rows
-    var gctable_rows = ground_characteristics_table.getElementsByTagName("tr");
+  // Ground Page Conversions
+  if (page_type == "ground") {
+    var page_specs_info = document.getElementsByClassName("specs_info");
 
-    // Header Row Conversions
-    var gctrow1_headers = gctable_rows[0].getElementsByTagName("th");
-    gctrow1_headers[1].innerHTML = "Max Speed (mph)";
-    // End Header Row Conversions
+    var mobility_specs;
 
-    // Arcade Row Conversions
-    var gctrow3_arcade = gctable_rows[2].getElementsByTagName("td");
+    for (var i = 0; i < page_specs_info.length; i++) {
+      // Find Mobility Specs
+      if (page_specs_info[i].getElementsByClassName("name")[0]) {
+        if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Speed") {
+          mobility_specs = page_specs_info[i];
+        }
+      }
+    }
 
-    var gctrow3_forward = KmhToMph(ParseValue(gctrow3_arcade[0].innerHTML));
-    gctrow3_arcade[0].innerHTML = gctrow3_forward;
+    // Convert Mobility Specs
+    if (mobility_specs) {
+      var ground_mobility_block = mobility_specs.getElementsByClassName("specs_char_block")[0];
+      var ground_speed_values = ground_mobility_block.getElementsByClassName("value");
 
-    var gctrow3_reverse = KmhToMph(ParseValue(gctrow3_arcade[1].innerHTML));
-    gctrow3_arcade[1].innerHTML = gctrow3_reverse;
-    // End AB Row Conversions
+      for (var i = 0; i < ground_speed_values.length; i++) {
+        if (ParseSpaces(ground_speed_values[i].innerHTML) != "forward/back") {
+          var speed_values = ParseSpaces(ground_speed_values[i].innerHTML).split("/");
+          var forward = KmhToMph(ParseValue(speed_values[0]));
+          var backward = KmhToMph(ParseValue(speed_values[1]));
 
-    // Realistic Row Conversions
-    var gctrow4_realistics = gctable_rows[3].getElementsByTagName("td");
+          ground_speed_values[i].innerHTML = forward + " / " + backward + " mph";
+        }
+      }
+    }
+    // End Mobility Specs
 
-    var gctrow4_forward = KmhToMph(ParseValue(gctrow4_realistics[0].innerHTML));
-    gctrow4_realistics[0].innerHTML = gctrow4_forward;
+    var wiki_tables = document.getElementsByClassName("wikitable");
 
-    var gctrow4_reverse = KmhToMph(ParseValue(gctrow4_realistics[1].innerHTML));
-    gctrow4_realistics[1].innerHTML = gctrow4_reverse;
-    // End RB/SB Row Conversions
+    // Find Data Tables
+    var ground_characteristics_table;
+    for (var i = 0; i < wiki_tables.length; i++) {
+      // Check if Mobility Characteristics Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "GameMode") {
+        console.log("found");
+        ground_characteristics_table = wiki_tables[i]
+      }
+    }
+
+    // Vehicle Characteristics Table Conversion
+    if (ground_characteristics_table) {
+      // Get all rows
+      var gctable_rows = ground_characteristics_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var gctrow1_headers = gctable_rows[0].getElementsByTagName("th");
+      gctrow1_headers[1].innerHTML = "Max Speed (mph)";
+      // End Header Row Conversions
+
+      // Arcade Row Conversions
+      var gctrow3_arcade = gctable_rows[2].getElementsByTagName("td");
+
+      var gctrow3_forward = KmhToMph(ParseValue(gctrow3_arcade[0].innerHTML));
+      gctrow3_arcade[0].innerHTML = gctrow3_forward;
+
+      var gctrow3_reverse = KmhToMph(ParseValue(gctrow3_arcade[1].innerHTML));
+      gctrow3_arcade[1].innerHTML = gctrow3_reverse;
+      // End AB Row Conversions
+
+      // Realistic Row Conversions
+      var gctrow4_realistics = gctable_rows[3].getElementsByTagName("td");
+
+      var gctrow4_forward = KmhToMph(ParseValue(gctrow4_realistics[0].innerHTML));
+      gctrow4_realistics[0].innerHTML = gctrow4_forward;
+
+      var gctrow4_reverse = KmhToMph(ParseValue(gctrow4_realistics[1].innerHTML));
+      gctrow4_realistics[1].innerHTML = gctrow4_reverse;
+      // End RB/SB Row Conversions
+    }
+  }
+  // End Fleet Page Conversions
+
+  // Helicopter Page conversions
+  if (page_type == "helicopters") {
+    var page_specs_info = document.getElementsByClassName("specs_info");
+
+    var heli_specs;
+    var survivability_specs;
+
+    for (var i = 0; i < page_specs_info.length; i++) {
+      // Find Helicopter Specs
+      if (page_specs_info[i].getElementsByClassName("name")[0]) {
+        if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Maxspeed") {
+          heli_specs = page_specs_info[i];
+        }
+      }
+
+      // Find Survivability Specs
+      if (page_specs_info[i].getElementsByClassName("name")[1]) {
+        if (ParseSpaces(page_specs_info[i].getElementsByClassName("name")[1].innerHTML) == "Speedofdestruction") {
+          survivability_specs = page_specs_info[i];
+        }
+      }
+    }
+
+    // Flight performance conversion
+    if (heli_specs) {
+      var heli_specs_blocks = heli_specs.getElementsByClassName("specs_char_block");
+      var heli_speed = heli_specs_blocks[0];
+      var heli_speed_alti = heli_speed.getElementsByClassName("name")[1];
+      var heli_speed_value = heli_speed.getElementsByClassName("value")[1];
+
+      // Convert Max speed at altitude
+      var max_speed_at_feet = MetersToFeet(ParseValue(heli_speed_alti.innerHTML));
+      heli_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
+
+      var max_speed_in_mph = KmhToMph(ParseValue(heli_speed_value.innerHTML));
+      heli_speed_value.innerHTML = max_speed_in_mph + " mph";
+      // End max speed conversion
+
+      // Convert Max altitude
+      var heli_altitude = heli_specs_blocks[1];
+      var heli_max_alti = heli_altitude.getElementsByClassName("value")[0];
+      var max_altitude_in_feet = MetersToFeet(ParseValue(heli_max_alti.innerHTML));
+      heli_max_alti.innerHTML = max_altitude_in_feet + " feet";
+      // End max altitude conversion
+    }
+    // End flight performance conversions
+
+    // Flight Survivability Conversions
+    if (survivability_specs) {
+      var survivability_specs_block = survivability_specs.getElementsByClassName("specs_char_block")[1];
+      var survivability_specs_block_values = survivability_specs_block.getElementsByClassName("value");
+
+      for (var i = 0; i < survivability_specs_block_values.length; i++) {
+        if (ParseSpaces(survivability_specs_block_values[i].innerHTML) != "") {
+          var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
+          survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
+        }
+      }
+    }
+    // End Survivability Conversions
+
+    var wiki_tables = document.getElementsByClassName("wikitable");
+
+    // Find Data Tables
+    var characteristics_table;
+    for (var i = 0; i < wiki_tables.length; i++) {
+      // Check if Characteristics Table
+      if (ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Characteristics") {
+        characteristics_table = wiki_tables[i]
+      }
+    }
+
+    // Heli Characteristics Table Conversion
+    if (characteristics_table) {
+      // Get all rows
+      var ctable_rows = characteristics_table.getElementsByTagName("tr");
+
+      // Header Row Conversions
+      var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
+      var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
+      ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
+
+      ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
+      // End Header Row Conversions
+
+      // Stock Row Conversions
+      var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
+
+      var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
+      ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
+
+      var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
+      ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
+
+      var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
+      ctrow3_stock[2].innerHTML = ctrow3_max_alti;
+      // End Stock Row Conversions
+
+      // Upgraded Row Conversions
+      var ctrow4_upgraded = ctable_rows[3].getElementsByTagName("td");
+
+      var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_upgraded[0].innerHTML));
+      ctrow4_upgraded[0].innerHTML = ctrow4_ms_ab;
+
+      var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_upgraded[1].innerHTML));
+      ctrow4_upgraded[1].innerHTML = ctrow4_ms_rb;
+      // End Upgraded Row Conversions
+    }
   }
 }
-// End Fleet Page Conversions
 
-// Helicopter Page conversions
-if(page_type == "helicopters"){
-  var page_specs_info = document.getElementsByClassName("specs_info");
-
-  var heli_specs;
-  var survivability_specs;
-
-  for(var i = 0; i < page_specs_info.length;i++){
-    // Find Helicopter Specs
-    if(page_specs_info[i].getElementsByClassName("name")[0]){
-      if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[0].innerHTML) == "Maxspeed"){
-        heli_specs = page_specs_info[i];
-      }
-    }
-
-    // Find Survivability Specs
-    if(page_specs_info[i].getElementsByClassName("name")[1]){
-      if(ParseSpaces(page_specs_info[i].getElementsByClassName("name")[1].innerHTML) == "Speedofdestruction"){
-        survivability_specs = page_specs_info[i];
-      }
-    }
-  }
-
-  // Flight performance conversion
-  if(heli_specs){
-    var heli_specs_blocks = heli_specs.getElementsByClassName("specs_char_block");
-    var heli_speed = heli_specs_blocks[0];
-    var heli_speed_alti = heli_speed.getElementsByClassName("name")[1];
-    var heli_speed_value = heli_speed.getElementsByClassName("value")[1];
-
-    // Convert Max speed at altitude
-    var max_speed_at_feet = MetersToFeet(ParseValue(heli_speed_alti.innerHTML));
-    heli_speed_alti.innerHTML = "at " + max_speed_at_feet + " feet";
-
-    var max_speed_in_mph = KmhToMph(ParseValue(heli_speed_value.innerHTML));
-    heli_speed_value.innerHTML = max_speed_in_mph + " mph";
-    // End max speed conversion
-
-    // Convert Max altitude
-    var heli_altitude = heli_specs_blocks[1];
-    var heli_max_alti = heli_altitude.getElementsByClassName("value")[0];
-    var max_altitude_in_feet = MetersToFeet(ParseValue(heli_max_alti.innerHTML));
-    heli_max_alti.innerHTML = max_altitude_in_feet + " feet";
-    // End max altitude conversion
-  }
-  // End flight performance conversions
-
-  // Flight Survivability Conversions
-  if(survivability_specs){
-    var survivability_specs_block = survivability_specs.getElementsByClassName("specs_char_block")[1];
-    var survivability_specs_block_values = survivability_specs_block.getElementsByClassName("value");
-
-    for(var i = 0; i < survivability_specs_block_values.length; i++){
-      if(ParseSpaces(survivability_specs_block_values[i].innerHTML) != ""){
-        var destruction_speed = KmhToMph(ParseValue(survivability_specs_block_values[i].innerHTML));
-        survivability_specs_block_values[i].innerHTML = destruction_speed + " mph";
-      }
-    }
-  }
-  // End Survivability Conversions
-
-  var wiki_tables = document.getElementsByClassName("wikitable");
-
-  // Find Data Tables
-  var characteristics_table;
-  for(var i = 0; i < wiki_tables.length; i++){
-    // Check if Characteristics Table
-    if(ParseSpaces(wiki_tables[i].getElementsByTagName("tr")[0].getElementsByTagName("th")[0].innerHTML) == "Characteristics"){
-      characteristics_table = wiki_tables[i]
-    }
-  }
-
-  // Heli Characteristics Table Conversion
-  if(characteristics_table){
-    // Get all rows
-    var ctable_rows = characteristics_table.getElementsByTagName("tr");
-
-    // Header Row Conversions
-    var ctrow1_headers = ctable_rows[0].getElementsByTagName("th");
-    var ctrow1_max_speed_at_altitude = MetersToFeet(ParseValue(ctrow1_headers[1].innerHTML));
-    ctrow1_headers[1].innerHTML = "Max Speed <br> (mph at " + ctrow1_max_speed_at_altitude + " feet)";
-
-    ctrow1_headers[2].innerHTML = "Max altitude <br> (feet)";
-    // End Header Row Conversions
-
-    // Stock Row Conversions
-    var ctrow3_stock = ctable_rows[2].getElementsByTagName("td");
-
-    var ctrow3_ms_ab = KmhToMph(ParseValue(ctrow3_stock[0].innerHTML));
-    ctrow3_stock[0].innerHTML = ctrow3_ms_ab;
-
-    var ctrow3_ms_rb = KmhToMph(ParseValue(ctrow3_stock[1].innerHTML));
-    ctrow3_stock[1].innerHTML = ctrow3_ms_rb;
-
-    var ctrow3_max_alti = MetersToFeet(ParseValue(ctrow3_stock[2].innerHTML));
-    ctrow3_stock[2].innerHTML = ctrow3_max_alti;
-    // End Stock Row Conversions
-
-    // Upgraded Row Conversions
-    var ctrow4_upgraded = ctable_rows[3].getElementsByTagName("td");
-
-    var ctrow4_ms_ab = KmhToMph(ParseValue(ctrow4_upgraded[0].innerHTML));
-    ctrow4_upgraded[0].innerHTML = ctrow4_ms_ab;
-
-    var ctrow4_ms_rb = KmhToMph(ParseValue(ctrow4_upgraded[1].innerHTML));
-    ctrow4_upgraded[1].innerHTML = ctrow4_ms_rb;
-    // End Upgraded Row Conversions
-  }
-}
+main();

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,16 @@
        "matches": ["https://wiki.warthunder.com/*"],
        "js": ["americanify.js"]
      }],
-     "browser_specific_settings": {
-       "gecko": {
-         "id": "{45d113f1-fd22-4649-9d5d-22d1bc3b8fd5}"
-       }
-     }
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "{45d113f1-fd22-4649-9d5d-22d1bc3b8fd5}"
+      }
+    },
+    "permissions": [
+      "storage"
+    ],
+    "options_ui": {
+      "page": "options.html",
+      "open_in_tab": false
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "WT Wiki Americanifier",
-    "version": "1.1",
+    "version": "2.0",
     "manifest_version": 3,
     "description": "Changes Km/h to Mph and Meters to Feet.",
     "icons": {

--- a/options.html
+++ b/options.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>War Thunder Wiki Americanifier Settings</title>
+</head>
+<body>
+<div>
+    <label>Speed</label>
+    <select id="speed">
+        <option value="mph">mph</option>
+        <option value="kts">kts</option>
+        <option value="km/h">km/h</option>
+    </select>
+</div>
+
+<div>
+    <label>Altitude</label>
+    <select id="altitude">
+        <option value="feet">feet</option>
+        <option value="meters">meters</option>
+    </select>
+</div>
+
+<div>
+    <label>Climb Speed</label>
+    <select id="climb-speed">
+        <option value="feet/minute">feet/minute</option>
+        <option value="meters/second">meters/second</option>
+    </select>
+</div>
+
+<div id="status"></div>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,29 @@
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+const defaultOptions = {speed: "mph", altitude: "feet", climbSpeed: "feet/minute"};
+const restoreOptions = () => {
+  chrome.storage.sync.get(defaultOptions).then((newOptions) => {
+    document.getElementById('speed').value = newOptions.speed;
+    document.getElementById('altitude').value = newOptions.altitude;
+    document.getElementById('climb-speed').value = newOptions.climbSpeed;
+  });
+};
+
+// Saves options to chrome.storage
+const saveOptions = () => {
+  const speed = document.getElementById('speed').value;
+  const altitude = document.getElementById('altitude').value;
+  const climbSpeed = document.getElementById('climb-speed').value;
+  const options = {speed, altitude, climbSpeed};
+
+  chrome.storage.sync.set(options).then(() => {
+    // Update status to let user know options were saved.
+    const status = document.getElementById('status');
+    status.textContent = 'Unit settings saved.';
+    setTimeout(() => {
+      status.textContent = '';
+    }, 750);
+  });
+};
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);


### PR DESCRIPTION
I like using kts as my airspeed, so I modified your extension to convert to a user chosen unit (note this syncs across computers if the user has the sync option set).

You can control which units to convert to via the extension options menu.

There are some minor refactoring that I've separated out to make some things work. Notably I renamed the conversion functions to not have their names just be the units they convert to and then putting all of the top level code into an async main function (so that I could load the setting synchronously).

I tested it locally and it seems to be working properly (converting to the saved units and updated the saved units).

Note: I also bumped the extension version to 2.0, since this is a pretty major change.

Let me know if you have any questions or changes for me and I hope that you'll merge this and release a new version.